### PR TITLE
fixed C lib paths in nodebox/setup.py

### DIFF
--- a/nodebox/setup.py
+++ b/nodebox/setup.py
@@ -61,9 +61,9 @@ The current version features:
 """
 
 ext_modules = [
-    Extension('cGeo', ['nodebox/ext/cGeo.c']),
-    Extension('cPathmatics', ['nodebox/ext/cPathmatics.c']),
-    Extension('cPolymagic', ['nodebox/ext/gpc.c', 'nodebox/ext/cPolymagic.m'], extra_link_args=['-framework', 'AppKit', '-framework', 'Foundation'])
+    Extension('cGeo', ['libs/cGeo/cGeo.c']),
+    Extension('cPathmatics', ['libs/pathmatics/pathmatics.c']),
+    Extension('cPolymagic', ['libs/polymagic/gpc.c', 'libs/polymagic/polymagic.m'], extra_link_args=['-framework', 'AppKit', '-framework', 'Foundation'])
     ]
 
 packages = ['nodebox', 'nodebox.graphics', 'nodebox.util', 'nodebox.geo']


### PR DESCRIPTION
Tried to install the usual `python nodebox/setup.py install` way, but some lib paths were outdated. After fixing these I'm able to install successfully.
